### PR TITLE
2 quick fixes

### DIFF
--- a/client/Assets/Scenes/Main.unity
+++ b/client/Assets/Scenes/Main.unity
@@ -4362,6 +4362,24 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 264307649}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &628926199 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 609108669033260349, guid: 0a65d425d4d081a4faaed2d47c9fe6f4,
+    type: 3}
+  m_PrefabInstance: {fileID: 609108668656541698}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &628926202
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 628926199}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b0aaf787be3854e278d80cc8c68fcb73, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!4 &630666354 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: 2b9f172d1ded61b49a257b979dbb6f1d,
@@ -14599,7 +14617,11 @@ PrefabInstance:
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
-    m_AddedComponents: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 609108669033260349, guid: 0a65d425d4d081a4faaed2d47c9fe6f4,
+        type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 628926202}
   m_SourcePrefab: {fileID: 100100000, guid: 0a65d425d4d081a4faaed2d47c9fe6f4, type: 3}
 --- !u!1 &2418756246391265779 stripped
 GameObject:

--- a/server/Lib.cs
+++ b/server/Lib.cs
@@ -144,7 +144,8 @@ static partial class Module
     }
     else
     {
-        throw new ArgumentException("Player not found");
+        // If the user doesn't exist they must create a user by calling CreatePlayer().
+        //throw new ArgumentException("Player not found");
     }
   }
 


### PR DESCRIPTION
There are 2 fixes here:
1. Server side fix which should not throw an error if the player isn't present in on connect (because the player has to be created from `CreatePlayer()`)
2. The `UnityNetworkManager.cs` script needed to exist in the scene. This is what updates the network stack so that network messages can be received/sent